### PR TITLE
Update tags in previous events page

### DIFF
--- a/data.js
+++ b/data.js
@@ -757,6 +757,6 @@ export const events = [
         social_network: "linkedin",
       },
     ],
-    photos: "",
+    photos: "https://web.facebook.com/share/ntTbM8Scy4bhGjW8/",
   },
 ];

--- a/pages/previous-events.js
+++ b/pages/previous-events.js
@@ -18,68 +18,77 @@ export default function PreviousEvents() {
           </h1>
         </section>
         <section>
-          {events.map((event, i) => (
-            <div key={`event#${i}`} className="mb-10">
-              <h2 className="font-big mb-5 text-xl">{event.date}</h2>
-              <p>El día {event.day} tuvimos las siguientes charlas:</p>
-              <div className="ml-5">
-                <ul>
-                  {event.talks.map((talk, i) => (
-                    <li
-                      key={`talk#${i}`}
-                      className="flex flex-col md:flex-row my-5 md:my-1"
-                    >
-                      <p># {talk.title}</p>
-                      <p className="hidden md:inline-block">&nbsp;-&nbsp;</p>
-                      <p className="text-blue-500">
-                        {talk.speaker}
-                        {talk.slide && (
-                          <a
-                            href={talk.slide}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            type="button"
-                            className="nes-btn is-error my-1 ml-4"
-                          >
-                            <svg className="h-3 w-3">
-                              <use xlinkHref="#slide" />
-                            </svg>
-                          </a>
-                        )}
-                        {talk.social_network && (
-                          <a
-                            href={talk.speaker_link}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            type="button"
-                            className="nes-btn is-primary my-1 mx-4"
-                          >
-                            <svg className="h-3 w-3">
-                              <use xlinkHref={`#${talk.social_network}`} />
-                            </svg>
-                          </a>
-                        )}
-                      </p>
-                    </li>
-                  ))}
-                </ul>
+          {events
+            .map((event, i) => (
+              <div key={`event#${i}`} className="mb-10">
+                <h2 className="font-big mb-5 text-xl">{event.date}</h2>
+
+                <details className="mb-5">
+                  <summary>
+                    El día {event.day} tuvimos las siguientes charlas:
+                  </summary>
+                  <div className="ml-5">
+                    <ul>
+                      {event.talks.map((talk, i) => (
+                        <li
+                          key={`talk#${i}`}
+                          className="flex flex-col md:flex-row my-5 md:my-1"
+                        >
+                          <p># {talk.title}</p>
+                          <p className="hidden md:inline-block">
+                            &nbsp;-&nbsp;
+                          </p>
+                          <p className="text-blue-500">
+                            {talk.speaker}
+                            {talk.slide && (
+                              <a
+                                href={talk.slide}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                type="button"
+                                className="nes-btn is-error my-1 ml-4"
+                              >
+                                <svg className="h-3 w-3">
+                                  <use xlinkHref="#slide" />
+                                </svg>
+                              </a>
+                            )}
+                            {talk.social_network && (
+                              <a
+                                href={talk.speaker_link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                type="button"
+                                className="nes-btn is-primary my-1 mx-4"
+                              >
+                                <svg className="h-3 w-3">
+                                  <use xlinkHref={`#${talk.social_network}`} />
+                                </svg>
+                              </a>
+                            )}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </details>
+                <p>
+                  Mira las fotos del evento
+                  <a
+                    href={event.photos}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    type="button"
+                    className="nes-btn is-primary my-1 ml-4"
+                  >
+                    <svg className="h-3 w-3">
+                      <use xlinkHref="#camara" />
+                    </svg>
+                  </a>
+                </p>
               </div>
-              <p>
-                Mira las fotos del evento
-                <a
-                  href={event.photos}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  type="button"
-                  className="nes-btn is-primary my-1 ml-4"
-                >
-                  <svg className="h-3 w-3">
-                    <use xlinkHref="#camara" />
-                  </svg>
-                </a>
-              </p>
-            </div>
-          )).reverse()}
+            ))
+            .reverse()}
         </section>
       </main>
     </Layout>

--- a/pages/previous-events.js
+++ b/pages/previous-events.js
@@ -25,7 +25,7 @@ export default function PreviousEvents() {
 
                 <details className="mb-5">
                   <summary>
-                    El día {event.day} tuvimos las siguientes charlas:
+                    El día {event.day} tuvimos las siguientes charlas: ⤵️
                   </summary>
                   <div className="ml-5">
                     <ul>

--- a/public/assets/css/_base.scss
+++ b/public/assets/css/_base.scss
@@ -11,7 +11,7 @@ h2 {
   @apply font-big;
 }
 
-p {
+p, summary {
   @apply font-small text-2xl;
 }
 


### PR DESCRIPTION
Se actualizó las etiquetas para la lista de `eventos anteriores`, con el propósito de disminuir el tamaño de la página.
`<details>` & `<summary>`

![image](https://github.com/user-attachments/assets/285d49e5-42cc-4f69-9dae-02c290c6d22c)
